### PR TITLE
Upgrade requests version to fix underlaying vulnerability on urllib3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ NAME = "appboy-client"
 VERSION = "0.0.1"
 
 REQUIRES = [
-    'requests==2.21.0',
+    'requests==2.22.0',
 ]
 
 EXTRAS = {


### PR DESCRIPTION
The cause of the following vulnerability [alert](https://saas.whitesourcesoftware.com/Wss/WSS.html#!libraryDetails;uuid=06adc918-d023-4945-a8af-aceb94feac40;project=2823691;orgToken=8795e8c5-6cc1-49a7-8812-68b34adad0f6) lies in this repository.


I'm updating to the next version that doesn't contain any major updates. 


References:

https://github.com/psf/requests/blob/v2.22.0/setup.py#L47